### PR TITLE
 add team invitation system and role-based access control

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS "user" (
   "image" TEXT,
   "username" TEXT UNIQUE,
   "displayUsername" TEXT,
+  "role" TEXT NOT NULL DEFAULT 'member',
   "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
   "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
 );
@@ -53,4 +54,16 @@ CREATE TABLE IF NOT EXISTS config_history (
   "payload" JSONB NOT NULL,
   "provider" TEXT NOT NULL,
   "comment" TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "invitation" (
+  "id" TEXT PRIMARY KEY,
+  "email" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'member',
+  "token" TEXT NOT NULL UNIQUE,
+  "expiresAt" TIMESTAMP NOT NULL,
+  "inviterId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Certificates } from "./pages/Certificates";
 import { Logs } from "./pages/Logs";
 import { Login } from "./pages/Login";
 import { Signup } from "./pages/Signup";
+import { Team } from "./pages/Team";
 
 const SESSION_KEY = "pd_session";
 
@@ -75,6 +76,7 @@ export function App() {
           <Route path="config" element={<Config />} />
           <Route path="certificates" element={<Certificates />} />
           <Route path="logs" element={<Logs />} />
+          <Route path="team" element={<Team />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { to: "/config", end: false, label: "Config" },
   { to: "/certificates", end: false, label: "Certificates" },
   { to: "/logs", end: false, label: "Logs" },
+  { to: "/team", end: false, label: "Team" },
 ];
 
 async function handleLogout(e: React.FormEvent) {

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -20,12 +20,33 @@ export function Signup() {
   const [loading, setLoading] = useState(false);
   const [allowSignup, setAllowSignup] = useState<boolean | null>(null);
   const [checkingSession, setCheckingSession] = useState(true);
+  const [inviteToken, setInviteToken] = useState<string | null>(null);
+  const [inviteInfo, setInviteInfo] = useState<{ email: string; role: string } | null>(null);
 
   useEffect(() => {
     if (readStoredSession()) {
       navigate("/", { replace: true });
       return;
     }
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+    if (token) {
+      setInviteToken(token);
+      fetch(`/api/invites/check/${token}`)
+        .then((r) => {
+          if (!r.ok) throw new Error("Invalid or expired invite");
+          return r.json();
+        })
+        .then((d) => {
+          setInviteInfo(d);
+          setAllowSignup(true);
+        })
+        .catch((e) => {
+          setError(e.message);
+          setAllowSignup(false);
+        });
+    }
+
     fetch("/api/auth/get-session", { credentials: "include" })
       .then((r) => r.text())
       .then((text) => {
@@ -38,12 +59,12 @@ export function Signup() {
   }, [navigate]);
 
   useEffect(() => {
-    if (checkingSession) return;
+    if (checkingSession || inviteToken) return;
     fetch("/api/allow-signup", { credentials: "include" })
       .then((r) => r.json())
       .then((d) => setAllowSignup(d?.allowSignup === true))
       .catch(() => setAllowSignup(false));
-  }, [checkingSession]);
+  }, [checkingSession, inviteToken]);
 
   useEffect(() => {
     if (allowSignup === false) navigate("/login", { replace: true });
@@ -98,7 +119,13 @@ export function Signup() {
         <article className="card p-4">
           <header className="mb-4">
             <h1>Create account</h1>
-            <p className="text-light">One-time setup. Only one user is allowed.</p>
+            {inviteInfo ? (
+              <p className="text-light">
+                You've been invited as <strong>{inviteInfo.email}</strong> with role <strong>{inviteInfo.role}</strong>.
+              </p>
+            ) : (
+              <p className="text-light">One-time setup. Only one user is allowed.</p>
+            )}
           </header>
           <form onSubmit={handleSubmit} className="vstack gap-4">
             <div data-field>

--- a/frontend/src/pages/Team.tsx
+++ b/frontend/src/pages/Team.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from "react";
+
+interface Invite {
+  id: string;
+  email: string;
+  role: string;
+  token: string;
+  status: string;
+  expiresAt: string;
+  inviterName: string;
+  createdAt: string;
+}
+
+export function Team() {
+  const [invites, setInvites] = useState<Invite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("member");
+  const [creating, setCreating] = useState(false);
+  const [user, setUser] = useState<{ role: string } | null>(null);
+
+  useEffect(() => {
+    // Get current user role from session
+    const raw = sessionStorage.getItem("pd_session");
+    if (raw) {
+      try {
+        const d = JSON.parse(raw);
+        setUser(d?.user ?? d?.data ?? d ?? null);
+      } catch {}
+    }
+
+    fetch("/api/invites")
+      .then((r) => r.json())
+      .then((d) => setInvites(Array.isArray(d) ? d : []))
+      .catch((e) => setError("Failed to load invites"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleCreateInvite(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+    setCreating(true);
+    setError("");
+    try {
+      const res = await fetch("/api/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, role }),
+      });
+      if (res.ok) {
+        const newInvite = await res.json();
+        setInvites([newInvite, ...invites]);
+        setEmail("");
+      } else {
+        const d = await res.json();
+        setError(d.error || "Failed to create invite");
+      }
+    } catch {
+      setError("Failed to create invite");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDeleteInvite(id: string) {
+    if (!confirm("Are you sure you want to revoke this invitation?")) return;
+    try {
+      const res = await fetch(`/api/invites/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setInvites(invites.filter((i) => i.id !== id));
+      }
+    } catch {
+      setError("Failed to delete invite");
+    }
+  }
+
+  const isAdmin = user?.role === "admin";
+
+  return (
+    <div className="vstack gap-6">
+      <header className="hstack justify-between">
+        <div>
+          <h1>Team & Invites</h1>
+          <p className="text-light">Manage who can access this dashboard.</p>
+        </div>
+      </header>
+
+      {isAdmin && (
+        <article className="card p-4">
+          <header className="mb-4">
+            <h2>Invite Team Member</h2>
+          </header>
+          <form onSubmit={handleCreateInvite} className="hstack gap-4 items-end">
+            <div data-field style={{ flex: 1 }}>
+              <label htmlFor="invite-email">Email Address</label>
+              <input
+                id="invite-email"
+                type="email"
+                placeholder="colleague@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div data-field>
+              <label htmlFor="invite-role">Role</label>
+              <select
+                id="invite-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                style={{ height: "2.5rem" }}
+              >
+                <option value="member">Member (Read/Write)</option>
+                <option value="admin">Admin (Manage Team)</option>
+              </select>
+            </div>
+            <button type="submit" disabled={creating} style={{ height: "2.5rem" }}>
+              {creating ? "Inviting..." : "Send Invite"}
+            </button>
+          </form>
+          {error && <p className="text-danger mt-2">{error}</p>}
+        </article>
+      )}
+
+      <article className="card overflow-hidden">
+        <header className="p-4 border-bottom">
+          <h2>Active & Pending Invitations</h2>
+        </header>
+        {loading ? (
+          <div className="p-4">Loading invites...</div>
+        ) : invites.length === 0 ? (
+          <div className="p-4 text-center grayscale opacity-50">
+            <p>No invitations yet.</p>
+          </div>
+        ) : (
+          <table className="w-100">
+            <thead>
+              <tr>
+                <th className="text-left p-4">Email</th>
+                <th className="text-left p-4">Role</th>
+                <th className="text-left p-4">Status</th>
+                <th className="text-left p-4">Invited By</th>
+                {isAdmin && <th className="text-right p-4">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {invites.map((invite) => (
+                <tr key={invite.id} className="border-top">
+                  <td className="p-4 font-mono">{invite.email}</td>
+                  <td className="p-4">
+                    <span className="badge">{invite.role}</span>
+                  </td>
+                  <td className="p-4">
+                    <span
+                      data-status={invite.status === "pending" ? "warning" : "success"}
+                      className="indicator"
+                    >
+                      {invite.status}
+                    </span>
+                  </td>
+                  <td className="p-4 text-light text-small">{invite.inviterName || "Unknown"}</td>
+                  {isAdmin && (
+                    <td className="p-4 text-right">
+                      {invite.status === "pending" && (
+                        <button
+                          className="outline small danger"
+                          onClick={() => handleDeleteInvite(invite.id)}
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </article>
+
+      <article className="card p-4 bg-muted">
+        <h3>How Invitations Work</h3>
+        <p className="text-small text-light">
+          When you invite someone, they must sign up using the exact email address you provided. 
+          The sign-up page will recognize their valid invitation and allow them to create an account.
+        </p>
+      </article>
+    </div>
+  );
+}

--- a/src/api/invites.ts
+++ b/src/api/invites.ts
@@ -1,0 +1,38 @@
+import { pool } from "../../db/pool";
+import { randomBytes, randomUUID } from "crypto";
+
+export async function listInvites() {
+  const r = await pool.query(`
+    SELECT i.*, u.name as "inviterName"
+    FROM "invitation" i
+    JOIN "user" u ON i."inviterId" = u.id
+    ORDER BY i."createdAt" DESC
+  `);
+  return r.rows;
+}
+
+export async function createInvite(email: string, role: string, inviterId: string) {
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days
+  const id = randomUUID();
+  
+  await pool.query(
+    `INSERT INTO "invitation" (id, email, role, token, "expiresAt", "inviterId")
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, email, role, token, expiresAt, inviterId]
+  );
+  
+  return { id, token, email, role, expiresAt };
+}
+
+export async function deleteInvite(id: string) {
+  await pool.query('DELETE FROM "invitation" WHERE id = $1', [id]);
+}
+
+export async function getInviteByToken(token: string) {
+  const r = await pool.query(
+    'SELECT * FROM "invitation" WHERE token = $1 AND status = \'pending\' AND "expiresAt" > NOW()',
+    [token]
+  );
+  return r.rows[0];
+}

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -14,16 +14,46 @@ export const auth = betterAuth({
     enabled: true,
   },
   plugins: [username()],
+  user: {
+    additionalFields: {
+      role: {
+        type: "string",
+        defaultValue: "member",
+        input: false,
+      },
+    },
+  },
   databaseHooks: {
     user: {
       create: {
-        before: async () => {
+        before: async ({ data }) => {
           const r = await pool.query<{ count: string }>('SELECT COUNT(*)::text FROM "user"');
           const count = parseInt(r.rows[0]?.count ?? "0", 10);
-          if (count >= 1) {
-            throw new Error("Signup disabled: only one user allowed.");
+          
+          if (count === 0) {
+            (data as any).role = "admin";
+            return;
           }
+
+          // Check if there's a valid invitation for this email
+          const inviteRes = await pool.query<{ id: string, role: string }>(
+            'SELECT id, role FROM "invitation" WHERE email = $1 AND status = \'pending\' AND "expiresAt" > NOW()',
+            [data.email]
+          );
+          
+          if (inviteRes.rows.length === 0) {
+            throw new Error("Signup disabled: valid invitation required for this email.");
+          }
+          
+          // Use the role from the invitation
+          (data as any).role = inviteRes.rows[0].role;
         },
+        after: async ({ user }) => {
+          await pool.query(
+            'UPDATE "invitation" SET status = \'accepted\', "updatedAt" = NOW() WHERE email = $1 AND status = \'pending\'',
+            [user.email]
+          );
+        }
       },
     },
   },

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -16,15 +16,16 @@ function getCookie(headers: Headers, name: string): string | null {
 }
 
 /** Resolve session from DB using cookie token. */
-async function getSessionFromDb(cookieValue: string): Promise<{ user: unknown } | null> {
+async function getSessionFromDb(cookieValue: string): Promise<{ user: { id: string, name: string, email: string, username: string | null, role: string } } | null> {
   const tokenPart = cookieValue.split(".")[0];
   const r = await pool.query<{
     id: string;
     name: string;
     email: string;
     username: string | null;
+    role: string;
   }>(
-    `SELECT u.id, u.name, u.email, u.username FROM session s
+    `SELECT u.id, u.name, u.email, u.username, u.role FROM session s
      JOIN "user" u ON s."userId" = u.id
      WHERE (s.token = $1 OR s.token = $2) AND s."expiresAt" > NOW()`,
     [cookieValue, tokenPart]
@@ -37,6 +38,7 @@ async function getSessionFromDb(cookieValue: string): Promise<{ user: unknown } 
       name: row.name,
       email: row.email,
       username: row.username,
+      role: row.role,
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,12 @@ import * as caddy from "./proxy/caddy";
 import * as traefik from "./proxy/traefik";
 import type { ProxyConfig } from "./proxy/types";
 import { getLogs } from "./api/logs";
+import { listInvites, createInvite, deleteInvite, getInviteByToken } from "./api/invites";
 
 const PORT = process.env.PORT ?? "3000";
 const FRONTEND_DIR = join(process.cwd(), "frontend", "dist");
 
-const PUBLIC_API_PATHS = ["/api/auth", "/api/allow-signup", "/api/proxy/status"];
+const PUBLIC_API_PATHS = ["/api/auth", "/api/allow-signup", "/api/proxy/status", "/api/invites/check"];
 
 async function apiAuthGuard({ request }: { request: Request }) {
   const pathname = new URL(request.url).pathname;
@@ -92,6 +93,25 @@ const app = new Elysia()
     const entry = await getById(id);
     if (!entry) return { ok: false, error: "Config not found" };
     return applyConfig(entry.payload);
+  })
+  .get("/api/invites", async () => listInvites())
+  .post("/api/invites", async ({ request, body }) => {
+    const session = await getSession(request);
+    if (session?.user?.role !== "admin") return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
+    const { email, role } = (typeof body === "string" ? JSON.parse(body) : body) as { email: string, role: string };
+    if (!email) return new Response(JSON.stringify({ error: "Email required" }), { status: 400 });
+    return createInvite(email, role || "member", session.user.id);
+  })
+  .delete("/api/invites/:id", async ({ request, params }) => {
+    const session = await getSession(request);
+    if (session?.user?.role !== "admin") return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
+    await deleteInvite(params.id);
+    return { ok: true };
+  })
+  .get("/api/invites/check/:token", async ({ params }) => {
+    const invite = await getInviteByToken(params.token);
+    if (!invite) return new Response(JSON.stringify({ error: "Invalid or expired invite" }), { status: 404, headers: { "Content-Type": "application/json" } });
+    return invite;
   })
   .all("/api/auth/*", async ({ request }) => auth.handler(request))
   .get("/*", ({ request }) => {


### PR DESCRIPTION
Implemented a comprehensive team invitation system to support collaborative infrastructure management. These changes enable the initial administrator to safely invite team members to the dashboard.

Key changes included:

- Database Schema: Added a role field to the user table and created a new invitation table to manage pending team requests.
- Auth Logic:
- The first user to sign up is automatically granted the admin role.
- Subsequent signups are restricted to users who have a valid, pending invitation.
- Enriched session data to include user roles for permission-based UI/API access.
- Invitation API: Developed backend endpoints for listing, creating, and revoking invitations, with admin-only protection for management actions.
- Frontend Updates:

1. Created a new Team management page for viewing and sending invites.
2. - Updated the Signup flow to verify invitation tokens from the URL (e.g., /signup?token=...).
3. - Integrated "Team" into the main navigation layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Team Management page accessible to authenticated users for managing team invitations.
  * Introduced team member invitations with role assignment and expiration handling.
  * Added admin-only controls to create and revoke pending invitations.
  * Implemented invitation-based signup flow; first user receives admin role, subsequent users require valid invitations.
  * Added Team navigation tab in main menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->