### PR TITLE
feat: add suport for export/import json and csv for domain portfolios

### DIFF
--- a/frontend/src/lib/portfolioBackup.ts
+++ b/frontend/src/lib/portfolioBackup.ts
@@ -1,0 +1,84 @@
+import { httpGet, httpPost } from "../utils/http";
+
+export type PortfolioImportSummary = {
+  dryRun: boolean;
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: { row: number; message: string }[];
+};
+
+export async function downloadPortfolioExport(
+  path: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await httpGet(path);
+    if (!res.ok) {
+      let msg = res.statusText;
+      try {
+        const j = (await res.json()) as { error?: string };
+        if (j?.error && typeof j.error === "string") msg = j.error;
+      } catch {
+        /* ignore */
+      }
+      return { ok: false, error: msg };
+    }
+    const blob = await res.blob();
+    const cd = res.headers.get("Content-Disposition");
+    const m = cd?.match(/filename="([^"]+)"/);
+    const filename = m?.[1] ?? "export.bin";
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Download failed" };
+  }
+}
+
+export async function postDomainsImport(body: Record<string, unknown>): Promise<
+  { ok: true; summary: PortfolioImportSummary } | { ok: false; error: string }
+> {
+  try {
+    const res = await httpPost("/api/domains/import", { json: body });
+    if (!res.ok) {
+      let msg = res.statusText;
+      try {
+        const j = (await res.json()) as { error?: string };
+        if (j?.error && typeof j.error === "string") msg = j.error;
+      } catch {
+        /* ignore */
+      }
+      return { ok: false, error: msg };
+    }
+    const summary = (await res.json()) as PortfolioImportSummary;
+    return { ok: true, summary };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Import failed" };
+  }
+}
+
+export async function postServersImport(body: Record<string, unknown>): Promise<
+  { ok: true; summary: PortfolioImportSummary } | { ok: false; error: string }
+> {
+  try {
+    const res = await httpPost("/api/servers/import", { json: body });
+    if (!res.ok) {
+      let msg = res.statusText;
+      try {
+        const j = (await res.json()) as { error?: string };
+        if (j?.error && typeof j.error === "string") msg = j.error;
+      } catch {
+        /* ignore */
+      }
+      return { ok: false, error: msg };
+    }
+    const summary = (await res.json()) as PortfolioImportSummary;
+    return { ok: true, summary };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Import failed" };
+  }
+}

--- a/frontend/src/pages/Servers.tsx
+++ b/frontend/src/pages/Servers.tsx
@@ -1,9 +1,14 @@
 import { Link } from "react-router-dom";
-import { Plus, Trash } from "@phosphor-icons/react";
+import { FileArrowDown, Plus, Trash } from "@phosphor-icons/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { ConfirmDialog, type ConfirmDialogHandle } from "../components/ConfirmDialog";
 import { OatFormModal, type OatFormModalHandle } from "../components/OatFormModal";
 import type { InfrastructureServer } from "../types/infrastructureServer";
+import {
+  downloadPortfolioExport,
+  postServersImport,
+  type PortfolioImportSummary,
+} from "../lib/portfolioBackup";
 import { useDomains } from "./hooks/useDomains";
 import { useServers } from "./hooks/useServers";
 
@@ -46,8 +51,17 @@ function parseTagsInput(raw: string): string[] {
     .filter(Boolean);
 }
 
+function summarizeServerImport(s: PortfolioImportSummary): string {
+  const bits = [
+    s.dryRun ? "Dry run (no changes saved)." : "Done.",
+    `created ${s.created}, updated ${s.updated}, skipped ${s.skipped}.`,
+  ];
+  if (s.errors.length) bits.push(`${s.errors.length} row(s) had errors.`);
+  return bits.join(" ");
+}
+
 export function Servers() {
-  const { servers, loading, error, create, update, remove } = useServers();
+  const { servers, loading, error, create, update, remove, reload } = useServers();
   const { domains, loading: domainsLoading } = useDomains();
   const [form, setForm] = useState(emptyForm);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -56,6 +70,12 @@ export function Servers() {
   const removeDialogRef = useRef<ConfirmDialogHandle>(null);
   const pendingRemoveId = useRef<string | null>(null);
   const serverModalRef = useRef<OatFormModalHandle>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [importBusy, setImportBusy] = useState(false);
+  const [importNote, setImportNote] = useState<string | null>(null);
+  const [importErrors, setImportErrors] = useState<{ row: number; message: string }[]>([]);
+  const [dupIdPolicy, setDupIdPolicy] = useState<"error" | "skip" | "update">("error");
+  const [dryRunImport, setDryRunImport] = useState(true);
 
   const domainById = useMemo(() => {
     const m = new Map<string, string>();
@@ -97,6 +117,78 @@ export function Servers() {
     if (!r.ok) setFormError(r.error);
     else if (editingId === id) resetForm();
   }, [remove, editingId, resetForm]);
+
+  const onExportJson = useCallback(async () => {
+    setImportNote(null);
+    const r = await downloadPortfolioExport("/api/servers/export?format=json");
+    if (!r.ok) setImportNote(r.error);
+  }, []);
+
+  const onExportCsv = useCallback(async () => {
+    setImportNote(null);
+    const r = await downloadPortfolioExport("/api/servers/export?format=csv");
+    if (!r.ok) setImportNote(r.error);
+  }, []);
+
+  const onImportFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = "";
+      if (!file) return;
+      setImportBusy(true);
+      setImportNote(null);
+      setImportErrors([]);
+      try {
+        const text = await file.text();
+        const lower = file.name.toLowerCase();
+        let body: Record<string, unknown>;
+        if (lower.endsWith(".csv")) {
+          body = {
+            format: "csv",
+            csv: text,
+            dryRun: dryRunImport,
+            onDuplicateId: dupIdPolicy,
+          };
+        } else {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(text) as unknown;
+          } catch {
+            setImportNote("Could not parse JSON.");
+            return;
+          }
+          const arr = Array.isArray(parsed)
+            ? parsed
+            : parsed &&
+                typeof parsed === "object" &&
+                Array.isArray((parsed as { servers?: unknown }).servers)
+              ? (parsed as { servers: unknown[] }).servers
+              : null;
+          if (!arr) {
+            setImportNote('JSON must be an array of servers or an object with a "servers" array.');
+            return;
+          }
+          body = {
+            format: "json",
+            servers: arr,
+            dryRun: dryRunImport,
+            onDuplicateId: dupIdPolicy,
+          };
+        }
+        const r = await postServersImport(body);
+        if (!r.ok) {
+          setImportNote(r.error);
+          return;
+        }
+        setImportErrors(r.summary.errors);
+        setImportNote(summarizeServerImport(r.summary));
+        if (!r.summary.dryRun && (r.summary.created > 0 || r.summary.updated > 0)) await reload();
+      } finally {
+        setImportBusy(false);
+      }
+    },
+    [dryRunImport, dupIdPolicy, reload]
+  );
 
   const toggleDomainLink = useCallback((domainId: string) => {
     setForm((f) => {
@@ -348,7 +440,7 @@ export function Servers() {
           Track Hetzner, Contabo, AWS EC2, and other hosts in one place. Link entries to portfolio domains for
           context. Store secrets in a password manager-never here.
         </p>
-        <div className="hstack gap-2 mt-4">
+        <div className="hstack gap-2 mt-4" style={{ flexWrap: "wrap", alignItems: "center" }}>
           <button
             type="button"
             className="button"
@@ -358,12 +450,88 @@ export function Servers() {
             <Plus size={20} weight="duotone" aria-hidden />
             Add server
           </button>
+          <button
+            type="button"
+            className="outline button"
+            style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+            onClick={() => void onExportJson()}
+            title="Download JSON backup"
+          >
+            <FileArrowDown size={20} weight="duotone" aria-hidden />
+            Export JSON
+          </button>
+          <button
+            type="button"
+            className="outline button"
+            style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+            onClick={() => void onExportCsv()}
+            title="Download CSV backup"
+          >
+            <FileArrowDown size={20} weight="duotone" aria-hidden />
+            Export CSV
+          </button>
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".json,.csv,application/json,text/csv"
+            style={{ display: "none" }}
+            aria-hidden
+            tabIndex={-1}
+            onChange={(ev) => void onImportFile(ev)}
+          />
+          <button
+            type="button"
+            className="outline button"
+            disabled={importBusy}
+            onClick={() => importInputRef.current?.click()}
+            title="Import from JSON or CSV (validated). Import domains first if you use linked hostnames."
+          >
+            {importBusy ? "Importing…" : "Import…"}
+          </button>
+          <label className="hstack gap-1 text-light" style={{ fontSize: "var(--text-7)", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={dryRunImport}
+              onChange={(e) => setDryRunImport(e.target.checked)}
+            />
+            Dry run
+          </label>
+          <label className="text-light" style={{ fontSize: "var(--text-7)", display: "flex", gap: "0.35rem", alignItems: "center" }}>
+            <span>If server id exists:</span>
+            <select
+              value={dupIdPolicy}
+              onChange={(e) => setDupIdPolicy(e.target.value as typeof dupIdPolicy)}
+              aria-label="Duplicate server id policy"
+            >
+              <option value="error">error</option>
+              <option value="skip">skip row</option>
+              <option value="update">update row</option>
+            </select>
+          </label>
         </div>
       </header>
 
       {error && (
         <div className="card mb-4" role="alert" data-variant="danger">
           {error}
+        </div>
+      )}
+
+      {(importNote || importErrors.length > 0) && (
+        <div className="card mb-4" role="status">
+          {importNote ? <p style={{ marginBlockEnd: importErrors.length ? "0.75rem" : 0 }}>{importNote}</p> : null}
+          {importErrors.length > 0 ? (
+            <ul style={{ margin: 0, paddingInlineStart: "1.25rem", fontSize: "var(--text-7)" }}>
+              {importErrors.slice(0, 20).map((err) => (
+                <li key={`${err.row}-${err.message}`}>
+                  Row {err.row}: {err.message}
+                </li>
+              ))}
+              {importErrors.length > 20 ? (
+                <li className="text-light">…and {importErrors.length - 20} more</li>
+              ) : null}
+            </ul>
+          ) : null}
         </div>
       )}
 

--- a/frontend/src/pages/domains/DomainList.tsx
+++ b/frontend/src/pages/domains/DomainList.tsx
@@ -1,7 +1,12 @@
-import { useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Plus } from "@phosphor-icons/react";
+import { FileArrowDown, Plus } from "@phosphor-icons/react";
 import type { Domain } from "../../types/domain";
+import {
+  downloadPortfolioExport,
+  postDomainsImport,
+  type PortfolioImportSummary,
+} from "../../lib/portfolioBackup";
 import type { AddDomainModalHandle } from "./AddDomainModal";
 import { AddDomainModal } from "./AddDomainModal";
 import { useDomains } from "../hooks/useDomains";
@@ -21,9 +26,96 @@ function tlsValidTo(d: Domain): string {
   return dt.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
+function summarizeImport(s: PortfolioImportSummary): string {
+  const bits = [
+    s.dryRun ? "Dry run (no changes saved)." : "Done.",
+    `created ${s.created}, updated ${s.updated}, skipped ${s.skipped}.`,
+  ];
+  if (s.errors.length) bits.push(`${s.errors.length} row(s) had errors.`);
+  return bits.join(" ");
+}
+
 export function DomainList() {
-  const { domains, loading, error } = useDomains();
+  const { domains, loading, error, reload } = useDomains();
   const addDomainModalRef = useRef<AddDomainModalHandle>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [importBusy, setImportBusy] = useState(false);
+  const [importNote, setImportNote] = useState<string | null>(null);
+  const [importErrors, setImportErrors] = useState<{ row: number; message: string }[]>([]);
+  const [dupPolicy, setDupPolicy] = useState<"error" | "skip" | "update">("error");
+  const [dryRunImport, setDryRunImport] = useState(true);
+
+  const onExportJson = useCallback(async () => {
+    setImportNote(null);
+    const r = await downloadPortfolioExport("/api/domains/export?format=json");
+    if (!r.ok) setImportNote(r.error);
+  }, []);
+
+  const onExportCsv = useCallback(async () => {
+    setImportNote(null);
+    const r = await downloadPortfolioExport("/api/domains/export?format=csv");
+    if (!r.ok) setImportNote(r.error);
+  }, []);
+
+  const onImportFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = "";
+      if (!file) return;
+      setImportBusy(true);
+      setImportNote(null);
+      setImportErrors([]);
+      try {
+        const text = await file.text();
+        const lower = file.name.toLowerCase();
+        let body: Record<string, unknown>;
+        if (lower.endsWith(".csv")) {
+          body = {
+            format: "csv",
+            csv: text,
+            dryRun: dryRunImport,
+            onDuplicateHostname: dupPolicy,
+          };
+        } else {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(text) as unknown;
+          } catch {
+            setImportNote("Could not parse JSON.");
+            return;
+          }
+          const arr = Array.isArray(parsed)
+            ? parsed
+            : parsed &&
+                typeof parsed === "object" &&
+                Array.isArray((parsed as { domains?: unknown }).domains)
+              ? (parsed as { domains: unknown[] }).domains
+              : null;
+          if (!arr) {
+            setImportNote('JSON must be an array of domains or an object with a "domains" array.');
+            return;
+          }
+          body = {
+            format: "json",
+            domains: arr,
+            dryRun: dryRunImport,
+            onDuplicateHostname: dupPolicy,
+          };
+        }
+        const r = await postDomainsImport(body);
+        if (!r.ok) {
+          setImportNote(r.error);
+          return;
+        }
+        setImportErrors(r.summary.errors);
+        setImportNote(summarizeImport(r.summary));
+        if (!r.summary.dryRun && (r.summary.created > 0 || r.summary.updated > 0)) await reload();
+      } finally {
+        setImportBusy(false);
+      }
+    },
+    [dryRunImport, dupPolicy, reload]
+  );
 
   if (loading) {
     return (
@@ -51,7 +143,7 @@ export function DomainList() {
       <header className="pd-page-header">
         <h1>Domains</h1>
         <p className="text-light">Your domain portfolio (separate from proxy site configuration).</p>
-        <div className="hstack gap-2 mt-4">
+        <div className="hstack gap-2 mt-4" style={{ flexWrap: "wrap", alignItems: "center" }}>
           <button
             type="button"
             className="button"
@@ -64,12 +156,88 @@ export function DomainList() {
           <Link to="/domains/servers" className="outline button">
             Servers
           </Link>
+          <button
+            type="button"
+            className="outline button"
+            style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+            onClick={() => void onExportJson()}
+            title="Download JSON backup"
+          >
+            <FileArrowDown size={20} weight="duotone" aria-hidden />
+            Export JSON
+          </button>
+          <button
+            type="button"
+            className="outline button"
+            style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+            onClick={() => void onExportCsv()}
+            title="Download CSV backup"
+          >
+            <FileArrowDown size={20} weight="duotone" aria-hidden />
+            Export CSV
+          </button>
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".json,.csv,application/json,text/csv"
+            style={{ display: "none" }}
+            aria-hidden
+            tabIndex={-1}
+            onChange={(ev) => void onImportFile(ev)}
+          />
+          <button
+            type="button"
+            className="outline button"
+            disabled={importBusy}
+            onClick={() => importInputRef.current?.click()}
+            title="Import from JSON or CSV (validated)"
+          >
+            {importBusy ? "Importing…" : "Import…"}
+          </button>
+          <label className="hstack gap-1 text-light" style={{ fontSize: "var(--text-7)", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={dryRunImport}
+              onChange={(e) => setDryRunImport(e.target.checked)}
+            />
+            Dry run
+          </label>
+          <label className="text-light" style={{ fontSize: "var(--text-7)", display: "flex", gap: "0.35rem", alignItems: "center" }}>
+            <span>If hostname exists:</span>
+            <select
+              value={dupPolicy}
+              onChange={(e) => setDupPolicy(e.target.value as typeof dupPolicy)}
+              aria-label="Duplicate hostname policy"
+            >
+              <option value="error">error</option>
+              <option value="skip">skip row</option>
+              <option value="update">update row</option>
+            </select>
+          </label>
         </div>
       </header>
 
       {error && (
         <div className="card mb-4" role="alert" data-variant="danger">
           {error}
+        </div>
+      )}
+
+      {(importNote || importErrors.length > 0) && (
+        <div className="card mb-4" role="status">
+          {importNote ? <p style={{ marginBlockEnd: importErrors.length ? "0.75rem" : 0 }}>{importNote}</p> : null}
+          {importErrors.length > 0 ? (
+            <ul style={{ margin: 0, paddingInlineStart: "1.25rem", fontSize: "var(--text-7)" }}>
+              {importErrors.slice(0, 20).map((err) => (
+                <li key={`${err.row}-${err.message}`}>
+                  Row {err.row}: {err.message}
+                </li>
+              ))}
+              {importErrors.length > 20 ? (
+                <li className="text-light">…and {importErrors.length - 20} more</li>
+              ) : null}
+            </ul>
+          ) : null}
         </div>
       )}
 

--- a/src/controllers/domain.controller.ts
+++ b/src/controllers/domain.controller.ts
@@ -9,6 +9,7 @@ import {
   lookupDomainForUser,
   updateDomainForUserRequest,
 } from "../services/domain.service";
+import { exportDomainsPortfolioResponse, importDomainsPortfolio } from "../services/domainPortfolio.service";
 
 const domainOpenapi = {
   tags: ["domains"],
@@ -16,6 +17,38 @@ const domainOpenapi = {
 
 export const domainRoutes = new Elysia().group("/api/domains", (app) =>
   app
+    .get(
+      "/export",
+      async ({ request }) => {
+        const url = new URL(request.url);
+        const format = url.searchParams.get("format");
+        const res = await exportDomainsPortfolioResponse(await getUserIdFromRequest(request), format);
+        return res instanceof Response ? res : toResponse(res);
+      },
+      {
+        detail: {
+          ...domainOpenapi,
+          summary: "Export domains (JSON or CSV)",
+          description: "Download portfolio backup. Use ?format=json or ?format=csv.",
+        },
+      }
+    )
+    .post(
+      "/import",
+      async ({ request }) =>
+        toResponse(
+          await importDomainsPortfolio(await getUserIdFromRequest(request), await readJsonBody(request))
+        ),
+      {
+        parse: "none",
+        detail: {
+          ...domainOpenapi,
+          summary: "Import domains (JSON or CSV)",
+          description:
+            "Body: { format, dryRun?, onDuplicateHostname?, domains? | csv }. Validates rows; optional dry run.",
+        },
+      }
+    )
     .get(
       "/",
       async ({ request }) =>

--- a/src/controllers/infrastructureServer.controller.ts
+++ b/src/controllers/infrastructureServer.controller.ts
@@ -8,6 +8,10 @@ import {
   listInfrastructureServersForUser,
   updateInfrastructureServerForUserRequest,
 } from "../services/infrastructureServer.service";
+import {
+  exportInfrastructureServersResponse,
+  importInfrastructureServersPortfolio,
+} from "../services/infrastructureServerPortfolio.service";
 
 const openapi = {
   tags: ["infrastructure"],
@@ -15,6 +19,41 @@ const openapi = {
 
 export const infrastructureServerRoutes = new Elysia().group("/api/servers", (app) =>
   app
+    .get(
+      "/export",
+      async ({ request }) => {
+        const url = new URL(request.url);
+        const format = url.searchParams.get("format");
+        const res = await exportInfrastructureServersResponse(await getUserIdFromRequest(request), format);
+        return res instanceof Response ? res : toResponse(res);
+      },
+      {
+        detail: {
+          ...openapi,
+          summary: "Export servers (JSON or CSV)",
+          description: "Download server inventory backup. Use ?format=json or ?format=csv.",
+        },
+      }
+    )
+    .post(
+      "/import",
+      async ({ request }) =>
+        toResponse(
+          await importInfrastructureServersPortfolio(
+            await getUserIdFromRequest(request),
+            await readJsonBody(request)
+          )
+        ),
+      {
+        parse: "none",
+        detail: {
+          ...openapi,
+          summary: "Import servers (JSON or CSV)",
+          description:
+            "Body: { format, dryRun?, onDuplicateId?, servers? | csv }. Validates rows; linkedHostnames resolves to portfolio domains.",
+        },
+      }
+    )
     .get(
       "/",
       async ({ request }) =>

--- a/src/portfolio/csv.ts
+++ b/src/portfolio/csv.ts
@@ -1,0 +1,75 @@
+/**
+ * Minimal RFC 4180-style CSV parse/stringify for portfolio import/export.
+ */
+
+export function escapeCsvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function stringifyCsv(rows: string[][]): string {
+  const lines = rows.map((row) => row.map((cell) => escapeCsvField(cell ?? "")).join(","));
+  return `${lines.join("\r\n")}\r\n`;
+}
+
+/**
+ * Parses CSV text into rows of raw string fields (no type coercion).
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let i = 0;
+  let inQuotes = false;
+  const s = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  while (i < s.length) {
+    const c = s[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (s[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += c;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (c === ",") {
+      row.push(field);
+      field = "";
+      i += 1;
+      continue;
+    }
+    if (c === "\n") {
+      row.push(field);
+      field = "";
+      rows.push(row);
+      row = [];
+      i += 1;
+      continue;
+    }
+    field += c;
+    i += 1;
+  }
+  row.push(field);
+  rows.push(row);
+
+  while (rows.length > 0 && rows[rows.length - 1]!.every((c) => c === "")) {
+    rows.pop();
+  }
+
+  return rows;
+}

--- a/src/repositories/domain.repository.ts
+++ b/src/repositories/domain.repository.ts
@@ -21,6 +21,18 @@ export async function findDomainByIdForUser(
   return rows[0];
 }
 
+export async function findDomainByHostnameForUser(
+  hostname: string,
+  userId: string
+): Promise<DomainRow | undefined> {
+  const rows = await db
+    .select()
+    .from(domains)
+    .where(and(eq(domains.userId, userId), eq(domains.hostname, hostname)))
+    .limit(1);
+  return rows[0];
+}
+
 export async function insertDomain(values: DomainInsert): Promise<DomainRow | undefined> {
   const [row] = await db.insert(domains).values(values).returning();
   return row;

--- a/src/services/domainPortfolio.service.ts
+++ b/src/services/domainPortfolio.service.ts
@@ -1,0 +1,408 @@
+import type { ApiResult } from "../types/api";
+import { dbFailureBody } from "../http/json";
+import { parseCsv, stringifyCsv } from "../portfolio/csv";
+import { isValidHostname, normalizeHostname, validateNotes, validateRegistrarName } from "../domains/hostname";
+import { enrichmentToStorable, isPgUniqueViolation, parseOptionalExpiresAt } from "../models/domain.model";
+import type { DomainInsert } from "../repositories/domain.repository";
+import {
+  findDomainByHostnameForUser,
+  findDomainByIdForUser,
+  findDomainsByUserId,
+  insertDomain,
+  updateDomainForUser,
+} from "../repositories/domain.repository";
+const MAX_ROWS = 5000;
+
+export type DuplicateHostnamePolicy = "error" | "skip" | "update";
+
+export type DomainExportRecord = {
+  id: string;
+  hostname: string;
+  registrarName: string | null;
+  expiresAt: string | null;
+  notes: string | null;
+  enrichment: DomainInsert["enrichment"];
+  enrichedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function unauthorized(): ApiResult {
+  return { status: 401, body: { error: "Unauthorized" } };
+}
+
+function uuidOk(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+function parseIsoOptional(raw: unknown): { ok: true; date: Date | null } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") return { ok: true, date: null };
+  if (typeof raw !== "string") return { ok: false, error: "Must be an ISO date string or empty" };
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return { ok: false, error: "Invalid date" };
+  return { ok: true, date: d };
+}
+
+function rowToExportRecord(row: unknown, index: number):
+  | { ok: true; value: DomainExportRecord }
+  | { ok: false; error: string } {
+  const rowNum = index + 1;
+  if (row === null || typeof row !== "object") {
+    return { ok: false, error: `Row ${rowNum}: expected object` };
+  }
+  const o = row as Record<string, unknown>;
+
+  const idRaw = o.id;
+  const id = typeof idRaw === "string" && uuidOk(idRaw.trim()) ? idRaw.trim() : "";
+
+  const hostnameRaw = o.hostname;
+  if (typeof hostnameRaw !== "string") {
+    return { ok: false, error: `Row ${rowNum}: hostname is required` };
+  }
+  const hostname = normalizeHostname(hostnameRaw);
+  if (!isValidHostname(hostname)) {
+    return { ok: false, error: `Row ${rowNum}: invalid hostname` };
+  }
+
+  const registrarRaw = o.registrarName;
+  const registrarName =
+    registrarRaw === undefined || registrarRaw === null
+      ? null
+      : typeof registrarRaw === "string"
+        ? registrarRaw
+        : undefined;
+  if (registrarName !== undefined && registrarName !== null && typeof registrarName !== "string") {
+    return { ok: false, error: `Row ${rowNum}: registrarName must be a string or null` };
+  }
+  const regErr = validateRegistrarName(registrarName ?? null);
+  if (regErr) return { ok: false, error: `Row ${rowNum}: ${regErr}` };
+
+  const notesRaw = o.notes;
+  if (notesRaw !== undefined && notesRaw !== null && typeof notesRaw !== "string") {
+    return { ok: false, error: `Row ${rowNum}: notes must be a string or null` };
+  }
+  const notesErr = validateNotes(typeof notesRaw === "string" ? notesRaw : null);
+  if (notesErr) return { ok: false, error: `Row ${rowNum}: ${notesErr}` };
+
+  const expiresParsed = parseOptionalExpiresAt(o.expiresAt);
+  if (!expiresParsed.ok) return { ok: false, error: `Row ${rowNum}: ${expiresParsed.error}` };
+
+  let enrichment: DomainInsert["enrichment"] = null;
+  if ("enrichment" in o && o.enrichment !== undefined && o.enrichment !== null) {
+    try {
+      enrichment = enrichmentToStorable(o.enrichment as never);
+    } catch {
+      return { ok: false, error: `Row ${rowNum}: enrichment is not valid JSON` };
+    }
+  }
+
+  const enrichedParsed = parseIsoOptional(o.enrichedAt);
+  if (!enrichedParsed.ok) return { ok: false, error: `Row ${rowNum}: ${enrichedParsed.error}` };
+
+  const createdParsed = parseIsoOptional(o.createdAt);
+  if (!createdParsed.ok) return { ok: false, error: `Row ${rowNum}: createdAt ${createdParsed.error}` };
+
+  const updatedParsed = parseIsoOptional(o.updatedAt);
+  if (!updatedParsed.ok) return { ok: false, error: `Row ${rowNum}: updatedAt ${updatedParsed.error}` };
+
+  const now = new Date().toISOString();
+  return {
+    ok: true,
+    value: {
+      id: id || crypto.randomUUID(),
+      hostname,
+      registrarName:
+        registrarName === undefined || registrarName === null || registrarName.trim() === ""
+          ? null
+          : registrarName.trim(),
+      expiresAt: expiresParsed.date ? expiresParsed.date.toISOString() : null,
+      notes:
+        notesRaw === undefined || notesRaw === null || notesRaw === ""
+          ? null
+          : (notesRaw as string),
+      enrichment,
+      enrichedAt: enrichedParsed.date ? enrichedParsed.date.toISOString() : null,
+      createdAt: createdParsed.date ? createdParsed.date.toISOString() : now,
+      updatedAt: updatedParsed.date ? updatedParsed.date.toISOString() : now,
+    },
+  };
+}
+
+export async function exportDomainsPortfolioResponse(
+  userId: string | null,
+  formatRaw: string | null
+): Promise<Response | ApiResult> {
+  if (!userId) return unauthorized();
+  const format = (formatRaw ?? "json").toLowerCase();
+  if (format !== "json" && format !== "csv") {
+    return { status: 400, body: { error: "Use ?format=json or ?format=csv" } };
+  }
+
+  try {
+    const rows = await findDomainsByUserId(userId);
+    const exportedAt = new Date().toISOString();
+    const payload = {
+      version: 1,
+      kind: "domains" as const,
+      exportedAt,
+      domains: rows.map((r) => ({
+        id: r.id,
+        hostname: r.hostname,
+        registrarName: r.registrarName,
+        expiresAt: r.expiresAt ? r.expiresAt.toISOString() : null,
+        notes: r.notes,
+        enrichment: r.enrichment ?? null,
+        enrichedAt: r.enrichedAt ? r.enrichedAt.toISOString() : null,
+        createdAt: r.createdAt.toISOString(),
+        updatedAt: r.updatedAt.toISOString(),
+      })),
+    };
+
+    if (format === "json") {
+      const filename = `domains-export-${exportedAt.slice(0, 10)}.json`;
+      return new Response(JSON.stringify(payload, null, 2), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+      });
+    }
+
+    const header = [
+      "id",
+      "hostname",
+      "registrarName",
+      "expiresAt",
+      "notes",
+      "enrichedAt",
+      "createdAt",
+      "updatedAt",
+      "enrichmentJson",
+    ];
+    const csvRows: string[][] = [header];
+    for (const d of payload.domains) {
+      csvRows.push([
+        d.id,
+        d.hostname,
+        d.registrarName ?? "",
+        d.expiresAt ?? "",
+        d.notes ?? "",
+        d.enrichedAt ?? "",
+        d.createdAt,
+        d.updatedAt,
+        d.enrichment ? JSON.stringify(d.enrichment) : "",
+      ]);
+    }
+    const csv = stringifyCsv(csvRows);
+    const filename = `domains-export-${exportedAt.slice(0, 10)}.csv`;
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (e) {
+    return dbFailureBody(e);
+  }
+}
+
+type ImportBody = {
+  format?: unknown;
+  dryRun?: unknown;
+  onDuplicateHostname?: unknown;
+  domains?: unknown;
+  csv?: unknown;
+};
+
+export async function importDomainsPortfolio(userId: string | null, body: unknown): Promise<ApiResult> {
+  if (!userId) return unauthorized();
+  if (body === null || typeof body !== "object") {
+    return { status: 400, body: { error: "Expected application/json body" } };
+  }
+  const b = body as ImportBody;
+  const format = typeof b.format === "string" ? b.format.toLowerCase() : "";
+  if (format !== "json" && format !== "csv") {
+    return { status: 400, body: { error: "format must be json or csv" } };
+  }
+  const dryRun = b.dryRun === true;
+  const dupPolicy: DuplicateHostnamePolicy =
+    b.onDuplicateHostname === "skip" || b.onDuplicateHostname === "update" ? b.onDuplicateHostname : "error";
+
+  let records: DomainExportRecord[] = [];
+
+  if (format === "json") {
+    if (!Array.isArray(b.domains)) {
+      return { status: 400, body: { error: "domains must be an array" } };
+    }
+    if (b.domains.length > MAX_ROWS) {
+      return { status: 400, body: { error: `At most ${MAX_ROWS} domains per import` } };
+    }
+    for (let i = 0; i < b.domains.length; i++) {
+      const parsed = rowToExportRecord(b.domains[i], i);
+      if (!parsed.ok) return { status: 400, body: { error: parsed.error } };
+      records.push(parsed.value);
+    }
+  } else {
+    if (typeof b.csv !== "string") {
+      return { status: 400, body: { error: "csv must be a string when format is csv" } };
+    }
+    const table = parseCsv(b.csv.trim());
+    if (table.length < 2) {
+      return { status: 400, body: { error: "CSV must include a header row and at least one data row" } };
+    }
+    const header = table[0]!.map((h) => h.trim().toLowerCase());
+    const idx = (name: string) => header.indexOf(name);
+
+    const colId = idx("id");
+    const colHost = idx("hostname");
+    const colReg = idx("registrarname");
+    const colExp = idx("expiresat");
+    const colNotes = idx("notes");
+    const colEnrAt = idx("enrichedat");
+    const colCreated = idx("createdat");
+    const colUpdated = idx("updatedat");
+    const colEnrJson = idx("enrichmentjson");
+
+    if (colHost < 0) {
+      return { status: 400, body: { error: 'CSV header must include a "hostname" column' } };
+    }
+
+    const dataRows = table.slice(1);
+    if (dataRows.length > MAX_ROWS) {
+      return { status: 400, body: { error: `At most ${MAX_ROWS} domains per import` } };
+    }
+
+    for (let r = 0; r < dataRows.length; r++) {
+      const row = dataRows[r]!;
+      const cell = (c: number) => (c >= 0 && c < row.length ? row[c] : "");
+
+      let enrichment: unknown = null;
+      if (colEnrJson >= 0 && cell(colEnrJson).trim() !== "") {
+        try {
+          enrichment = JSON.parse(cell(colEnrJson));
+        } catch {
+          return { status: 400, body: { error: `Row ${r + 2}: enrichmentJson is not valid JSON` } };
+        }
+      }
+
+      const obj: Record<string, unknown> = {
+        id: colId >= 0 ? cell(colId) : "",
+        hostname: cell(colHost),
+        registrarName: colReg >= 0 ? cell(colReg) || null : null,
+        expiresAt: colExp >= 0 ? cell(colExp) || null : null,
+        notes: colNotes >= 0 ? cell(colNotes) || null : null,
+        enrichedAt: colEnrAt >= 0 ? cell(colEnrAt) || null : null,
+        createdAt: colCreated >= 0 ? cell(colCreated) || null : null,
+        updatedAt: colUpdated >= 0 ? cell(colUpdated) || null : null,
+        enrichment,
+      };
+
+      const parsed = rowToExportRecord(obj, r);
+      if (!parsed.ok) return { status: 400, body: { error: parsed.error } };
+      records.push(parsed.value);
+    }
+  }
+
+  const errors: { row: number; message: string }[] = [];
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  try {
+    for (let i = 0; i < records.length; i++) {
+      const rec = records[i]!;
+      const rowNum = i + 1;
+      const byHostname = await findDomainByHostnameForUser(rec.hostname, userId);
+      let byId = rec.id ? await findDomainByIdForUser(rec.id, userId) : undefined;
+
+      if (byId && byHostname && byId.id !== byHostname.id) {
+        errors.push({
+          row: rowNum,
+          message: "Import id and hostname refer to different existing records",
+        });
+        continue;
+      }
+
+      const existing = byId ?? byHostname;
+
+      if (existing) {
+        if (dupPolicy === "skip") {
+          skipped += 1;
+          continue;
+        }
+        if (dupPolicy === "error") {
+          errors.push({ row: rowNum, message: "Duplicate hostname (or id) already exists" });
+          continue;
+        }
+        if (dryRun) {
+          updated += 1;
+          continue;
+        }
+        const now = new Date();
+        const updatedRow = await updateDomainForUser(existing.id, userId, {
+          hostname: rec.hostname,
+          registrarName: rec.registrarName,
+          notes: rec.notes,
+          expiresAt: rec.expiresAt ? new Date(rec.expiresAt) : null,
+          enrichment: rec.enrichment ?? null,
+          enrichedAt: rec.enrichedAt ? new Date(rec.enrichedAt) : null,
+          updatedAt: now,
+        });
+        if (!updatedRow) {
+          errors.push({ row: rowNum, message: "Update failed" });
+          continue;
+        }
+        updated += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        created += 1;
+        continue;
+      }
+
+      const now = new Date();
+      try {
+        const inserted = await insertDomain({
+          id: rec.id,
+          userId,
+          hostname: rec.hostname,
+          registrarName: rec.registrarName,
+          expiresAt: rec.expiresAt ? new Date(rec.expiresAt) : null,
+          notes: rec.notes,
+          enrichment: rec.enrichment ?? null,
+          enrichedAt: rec.enrichedAt ? new Date(rec.enrichedAt) : null,
+          createdAt: rec.createdAt ? new Date(rec.createdAt) : now,
+          updatedAt: rec.updatedAt ? new Date(rec.updatedAt) : now,
+        });
+        if (!inserted) {
+          errors.push({ row: rowNum, message: "Insert failed" });
+          continue;
+        }
+        created += 1;
+      } catch (e) {
+        if (isPgUniqueViolation(e)) {
+          errors.push({ row: rowNum, message: "Duplicate hostname or id" });
+        } else {
+          const msg = e instanceof Error ? e.message : "Database error";
+          errors.push({ row: rowNum, message: msg });
+        }
+      }
+    }
+
+    return {
+      status: 200,
+      body: {
+        dryRun,
+        created,
+        updated,
+        skipped,
+        errors,
+      },
+    };
+  } catch (e) {
+    return dbFailureBody(e);
+  }
+}

--- a/src/services/infrastructureServerPortfolio.service.ts
+++ b/src/services/infrastructureServerPortfolio.service.ts
@@ -1,0 +1,567 @@
+import type { ApiResult } from "../types/api";
+import { dbFailureBody } from "../http/json";
+import { parseCsv, stringifyCsv } from "../portfolio/csv";
+import { normalizeHostname } from "../domains/hostname";
+import type { InfrastructureServerInsert } from "../repositories/infrastructureServer.repository";
+import {
+  findInfrastructureServerByIdForUser,
+  findInfrastructureServersByUserId,
+  insertInfrastructureServer,
+  updateInfrastructureServerForUser,
+} from "../repositories/infrastructureServer.repository";
+import { findDomainsByUserId } from "../repositories/domain.repository";
+
+const MAX_ROWS = 5000;
+
+const LIMITS = {
+  providerMax: 64,
+  nameMax: 200,
+  regionMax: 128,
+  roleMax: 128,
+  environmentMax: 64,
+  notesMax: 10000,
+  urlMax: 2048,
+  tagsMaxCount: 32,
+  tagMaxLen: 64,
+  linkedDomainIdsMax: 50,
+} as const;
+
+function unauthorized(): ApiResult {
+  return { status: 401, body: { error: "Unauthorized" } };
+}
+
+function trimOrNull(v: string | null | undefined): string | null {
+  if (v === undefined || v === null) return null;
+  const t = v.trim();
+  return t === "" ? null : t;
+}
+
+function parseHttpsUrl(raw: unknown, field: string): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") return { ok: true, value: null };
+  if (typeof raw !== "string") return { ok: false, error: `${field} must be a string or null` };
+  const t = raw.trim();
+  if (t === "") return { ok: true, value: null };
+  if (t.length > LIMITS.urlMax) return { ok: false, error: `${field} is too long` };
+  let u: URL;
+  try {
+    u = new URL(t);
+  } catch {
+    return { ok: false, error: `${field} must be a valid URL` };
+  }
+  if (u.protocol !== "https:") {
+    return { ok: false, error: `${field} must use https` };
+  }
+  return { ok: true, value: t };
+}
+
+function parseTags(raw: unknown): { ok: true; value: string[] } | { ok: false; error: string } {
+  if (raw === undefined || raw === null) return { ok: true, value: [] };
+  if (!Array.isArray(raw)) return { ok: false, error: "tags must be an array of strings" };
+  if (raw.length > LIMITS.tagsMaxCount) {
+    return { ok: false, error: `At most ${LIMITS.tagsMaxCount} tags` };
+  }
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") return { ok: false, error: "Each tag must be a string" };
+    const t = item.trim();
+    if (t === "") continue;
+    if (t.length > LIMITS.tagMaxLen) {
+      return { ok: false, error: `Each tag must be at most ${LIMITS.tagMaxLen} characters` };
+    }
+    out.push(t);
+  }
+  return { ok: true, value: out };
+}
+
+function uuidOk(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
+
+async function resolveLinkedDomainIds(
+  userId: string,
+  linkedDomainIds: unknown,
+  linkedHostnames: unknown
+): Promise<{ ok: true; value: string[] } | { ok: false; error: string }> {
+  const domains = await findDomainsByUserId(userId);
+  const allowed = new Set(domains.map((d) => d.id));
+  const byHost = new Map(domains.map((d) => [normalizeHostname(d.hostname), d.id]));
+
+  const ids: string[] = [];
+  if (linkedDomainIds !== undefined && linkedDomainIds !== null) {
+    if (!Array.isArray(linkedDomainIds)) return { ok: false, error: "linkedDomainIds must be an array of strings" };
+    if (linkedDomainIds.length > LIMITS.linkedDomainIdsMax) {
+      return { ok: false, error: `At most ${LIMITS.linkedDomainIdsMax} linked domains` };
+    }
+    for (const id of linkedDomainIds) {
+      if (typeof id !== "string" || id.trim() === "") {
+        return { ok: false, error: "Each linkedDomainId must be a non-empty string" };
+      }
+      const tid = id.trim();
+      if (!allowed.has(tid)) {
+        return { ok: false, error: "linkedDomainIds must reference your portfolio domains only" };
+      }
+      ids.push(tid);
+    }
+  }
+
+  if (linkedHostnames !== undefined && linkedHostnames !== null) {
+    if (!Array.isArray(linkedHostnames)) {
+      return { ok: false, error: "linkedHostnames must be an array of strings" };
+    }
+    for (const h of linkedHostnames) {
+      if (typeof h !== "string") return { ok: false, error: "Each linkedHostname must be a string" };
+      const hn = normalizeHostname(h);
+      if (!hn) continue;
+      const did = byHost.get(hn);
+      if (!did) {
+        return { ok: false, error: `Unknown hostname in linkedHostnames: ${h}` };
+      }
+      ids.push(did);
+    }
+  }
+
+  const unique = [...new Set(ids)];
+  if (unique.length > LIMITS.linkedDomainIdsMax) {
+    return { ok: false, error: `At most ${LIMITS.linkedDomainIdsMax} linked domains after merge` };
+  }
+  return { ok: true, value: unique };
+}
+
+type ServerImportRecord = {
+  id: string;
+  provider: string;
+  region: string | null;
+  name: string;
+  role: string | null;
+  environment: string | null;
+  notes: string | null;
+  consoleUrl: string | null;
+  runbookUrl: string | null;
+  tags: string[];
+  linkedDomainIds: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+async function rowToServerRecord(
+  userId: string,
+  row: unknown,
+  index: number
+): Promise<{ ok: true; value: ServerImportRecord } | { ok: false; error: string }> {
+  const rowNum = index + 1;
+  if (row === null || typeof row !== "object") {
+    return { ok: false, error: `Row ${rowNum}: expected object` };
+  }
+  const o = row as Record<string, unknown>;
+
+  const idRaw = o.id;
+  const id =
+    typeof idRaw === "string" && uuidOk(idRaw.trim()) ? idRaw.trim() : crypto.randomUUID();
+
+  const providerRaw = o.provider;
+  if (typeof providerRaw !== "string" || providerRaw.trim() === "") {
+    return { ok: false, error: `Row ${rowNum}: provider is required` };
+  }
+  const provider = providerRaw.trim();
+  if (provider.length > LIMITS.providerMax) {
+    return { ok: false, error: `Row ${rowNum}: provider is too long` };
+  }
+
+  const nameRaw = o.name;
+  if (typeof nameRaw !== "string" || nameRaw.trim() === "") {
+    return { ok: false, error: `Row ${rowNum}: name is required` };
+  }
+  const name = nameRaw.trim();
+  if (name.length > LIMITS.nameMax) {
+    return { ok: false, error: `Row ${rowNum}: name is too long` };
+  }
+
+  const region = trimOrNull(typeof o.region === "string" ? o.region : null);
+  if (region && region.length > LIMITS.regionMax) {
+    return { ok: false, error: `Row ${rowNum}: region is too long` };
+  }
+
+  const role = trimOrNull(typeof o.role === "string" ? o.role : null);
+  if (role && role.length > LIMITS.roleMax) {
+    return { ok: false, error: `Row ${rowNum}: role is too long` };
+  }
+
+  const environment = trimOrNull(typeof o.environment === "string" ? o.environment : null);
+  if (environment && environment.length > LIMITS.environmentMax) {
+    return { ok: false, error: `Row ${rowNum}: environment is too long` };
+  }
+
+  let notes: string | null = null;
+  if ("notes" in o && o.notes !== undefined && o.notes !== null) {
+    if (typeof o.notes !== "string") return { ok: false, error: `Row ${rowNum}: notes must be a string or null` };
+    notes = trimOrNull(o.notes);
+  }
+  if (notes && notes.length > LIMITS.notesMax) {
+    return { ok: false, error: `Row ${rowNum}: notes is too long` };
+  }
+
+  const consoleParsed = parseHttpsUrl(o.consoleUrl, "consoleUrl");
+  if (!consoleParsed.ok) return { ok: false, error: `Row ${rowNum}: ${consoleParsed.error}` };
+
+  const runbookParsed = parseHttpsUrl(o.runbookUrl, "runbookUrl");
+  if (!runbookParsed.ok) return { ok: false, error: `Row ${rowNum}: ${runbookParsed.error}` };
+
+  const tagsParsed = parseTags(o.tags);
+  if (!tagsParsed.ok) return { ok: false, error: `Row ${rowNum}: ${tagsParsed.error}` };
+
+  const linkedParsed = await resolveLinkedDomainIds(userId, o.linkedDomainIds, o.linkedHostnames);
+  if (!linkedParsed.ok) return { ok: false, error: `Row ${rowNum}: ${linkedParsed.error}` };
+
+  const now = new Date().toISOString();
+  const createdAt =
+    typeof o.createdAt === "string" && !Number.isNaN(new Date(o.createdAt).getTime())
+      ? new Date(o.createdAt).toISOString()
+      : now;
+  const updatedAt =
+    typeof o.updatedAt === "string" && !Number.isNaN(new Date(o.updatedAt).getTime())
+      ? new Date(o.updatedAt).toISOString()
+      : now;
+
+  return {
+    ok: true,
+    value: {
+      id,
+      provider,
+      region,
+      name,
+      role,
+      environment,
+      notes,
+      consoleUrl: consoleParsed.value,
+      runbookUrl: runbookParsed.value,
+      tags: tagsParsed.value,
+      linkedDomainIds: linkedParsed.value,
+      createdAt,
+      updatedAt,
+    },
+  };
+}
+
+export async function exportInfrastructureServersResponse(
+  userId: string | null,
+  formatRaw: string | null
+): Promise<Response | ApiResult> {
+  if (!userId) return unauthorized();
+  const format = (formatRaw ?? "json").toLowerCase();
+  if (format !== "json" && format !== "csv") {
+    return { status: 400, body: { error: "Use ?format=json or ?format=csv" } };
+  }
+
+  try {
+    const [servers, domains] = await Promise.all([
+      findInfrastructureServersByUserId(userId),
+      findDomainsByUserId(userId),
+    ]);
+    const domainHostById = new Map(domains.map((d) => [d.id, d.hostname]));
+    const exportedAt = new Date().toISOString();
+
+    const serversOut = servers.map((s) => {
+      const linked = Array.isArray(s.linkedDomainIds) ? s.linkedDomainIds : [];
+      const linkedHostnames = linked
+        .map((id) => domainHostById.get(id))
+        .filter((h): h is string => !!h);
+      return {
+        id: s.id,
+        provider: s.provider,
+        region: s.region,
+        name: s.name,
+        role: s.role,
+        environment: s.environment,
+        notes: s.notes,
+        consoleUrl: s.consoleUrl,
+        runbookUrl: s.runbookUrl,
+        tags: Array.isArray(s.tags) ? s.tags : [],
+        linkedDomainIds: linked,
+        linkedHostnames,
+        createdAt: s.createdAt.toISOString(),
+        updatedAt: s.updatedAt.toISOString(),
+      };
+    });
+
+    const payload = {
+      version: 1,
+      kind: "servers" as const,
+      exportedAt,
+      servers: serversOut,
+    };
+
+    if (format === "json") {
+      const filename = `servers-export-${exportedAt.slice(0, 10)}.json`;
+      return new Response(JSON.stringify(payload, null, 2), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+      });
+    }
+
+    const header = [
+      "id",
+      "provider",
+      "region",
+      "name",
+      "role",
+      "environment",
+      "notes",
+      "consoleUrl",
+      "runbookUrl",
+      "tagsJson",
+      "linkedDomainIdsJson",
+      "linkedHostnames",
+      "createdAt",
+      "updatedAt",
+    ];
+    const csvRows: string[][] = [header];
+    for (const s of serversOut) {
+      csvRows.push([
+        s.id,
+        s.provider,
+        s.region ?? "",
+        s.name,
+        s.role ?? "",
+        s.environment ?? "",
+        s.notes ?? "",
+        s.consoleUrl ?? "",
+        s.runbookUrl ?? "",
+        JSON.stringify(s.tags),
+        JSON.stringify(s.linkedDomainIds),
+        s.linkedHostnames.join("|"),
+        s.createdAt,
+        s.updatedAt,
+      ]);
+    }
+    const csv = stringifyCsv(csvRows);
+    const filename = `servers-export-${exportedAt.slice(0, 10)}.csv`;
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (e) {
+    return dbFailureBody(e);
+  }
+}
+
+type ImportBody = {
+  format?: unknown;
+  dryRun?: unknown;
+  onDuplicateId?: unknown;
+  servers?: unknown;
+  csv?: unknown;
+};
+
+export async function importInfrastructureServersPortfolio(userId: string | null, body: unknown): Promise<ApiResult> {
+  if (!userId) return unauthorized();
+  if (body === null || typeof body !== "object") {
+    return { status: 400, body: { error: "Expected application/json body" } };
+  }
+  const b = body as ImportBody;
+  const format = typeof b.format === "string" ? b.format.toLowerCase() : "";
+  if (format !== "json" && format !== "csv") {
+    return { status: 400, body: { error: "format must be json or csv" } };
+  }
+  const dryRun = b.dryRun === true;
+  const dupPolicy =
+    b.onDuplicateId === "skip" || b.onDuplicateId === "update" ? b.onDuplicateId : "error";
+
+  let records: ServerImportRecord[] = [];
+
+  if (format === "json") {
+    if (!Array.isArray(b.servers)) {
+      return { status: 400, body: { error: "servers must be an array" } };
+    }
+    if (b.servers.length > MAX_ROWS) {
+      return { status: 400, body: { error: `At most ${MAX_ROWS} servers per import` } };
+    }
+    for (let i = 0; i < b.servers.length; i++) {
+      const parsed = await rowToServerRecord(userId, b.servers[i], i);
+      if (!parsed.ok) return { status: 400, body: { error: parsed.error } };
+      records.push(parsed.value);
+    }
+  } else {
+    if (typeof b.csv !== "string") {
+      return { status: 400, body: { error: "csv must be a string when format is csv" } };
+    }
+    const table = parseCsv(b.csv.trim());
+    if (table.length < 2) {
+      return { status: 400, body: { error: "CSV must include a header row and at least one data row" } };
+    }
+    const header = table[0]!.map((h) => h.trim().toLowerCase());
+    const idx = (name: string) => header.indexOf(name);
+
+    const colId = idx("id");
+    const colProv = idx("provider");
+    const colRegion = idx("region");
+    const colName = idx("name");
+    const colRole = idx("role");
+    const colEnv = idx("environment");
+    const colNotes = idx("notes");
+    const colConsole = idx("consoleurl");
+    const colRunbook = idx("runbookurl");
+    const colTags = idx("tagsjson");
+    const colLinked = idx("linkeddomainidsjson");
+    const colLinkedHosts = idx("linkedhostnames");
+    const colCreated = idx("createdat");
+    const colUpdated = idx("updatedat");
+
+    if (colProv < 0 || colName < 0) {
+      return { status: 400, body: { error: 'CSV header must include "provider" and "name" columns' } };
+    }
+
+    const dataRows = table.slice(1);
+    if (dataRows.length > MAX_ROWS) {
+      return { status: 400, body: { error: `At most ${MAX_ROWS} servers per import` } };
+    }
+
+    for (let r = 0; r < dataRows.length; r++) {
+      const row = dataRows[r]!;
+      const cell = (c: number) => (c >= 0 && c < row.length ? row[c] : "");
+
+      let tags: unknown = [];
+      if (colTags >= 0 && cell(colTags).trim() !== "") {
+        try {
+          tags = JSON.parse(cell(colTags));
+        } catch {
+          return { status: 400, body: { error: `Row ${r + 2}: tagsJson is not valid JSON` } };
+        }
+      }
+
+      let linkedDomainIds: unknown = [];
+      if (colLinked >= 0 && cell(colLinked).trim() !== "") {
+        try {
+          linkedDomainIds = JSON.parse(cell(colLinked));
+        } catch {
+          return { status: 400, body: { error: `Row ${r + 2}: linkedDomainIdsJson is not valid JSON` } };
+        }
+      }
+
+      let linkedHostnames: unknown = [];
+      if (colLinkedHosts >= 0 && cell(colLinkedHosts).trim() !== "") {
+        linkedHostnames = cell(colLinkedHosts)
+          .split("|")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+
+      const obj: Record<string, unknown> = {
+        id: colId >= 0 ? cell(colId) : "",
+        provider: cell(colProv),
+        region: colRegion >= 0 ? cell(colRegion) || null : null,
+        name: cell(colName),
+        role: colRole >= 0 ? cell(colRole) || null : null,
+        environment: colEnv >= 0 ? cell(colEnv) || null : null,
+        notes: colNotes >= 0 ? cell(colNotes) || null : null,
+        consoleUrl: colConsole >= 0 ? cell(colConsole) || null : null,
+        runbookUrl: colRunbook >= 0 ? cell(colRunbook) || null : null,
+        tags,
+        linkedDomainIds,
+        linkedHostnames,
+        createdAt: colCreated >= 0 ? cell(colCreated) || null : null,
+        updatedAt: colUpdated >= 0 ? cell(colUpdated) || null : null,
+      };
+
+      const parsed = await rowToServerRecord(userId, obj, r);
+      if (!parsed.ok) return { status: 400, body: { error: parsed.error } };
+      records.push(parsed.value);
+    }
+  }
+
+  const errors: { row: number; message: string }[] = [];
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  try {
+    for (let i = 0; i < records.length; i++) {
+      const rec = records[i]!;
+      const rowNum = i + 1;
+      const existing = await findInfrastructureServerByIdForUser(rec.id, userId);
+
+      if (existing) {
+        if (dupPolicy === "skip") {
+          skipped += 1;
+          continue;
+        }
+        if (dupPolicy === "error") {
+          errors.push({ row: rowNum, message: "Server id already exists" });
+          continue;
+        }
+        if (dryRun) {
+          updated += 1;
+          continue;
+        }
+        const now = new Date();
+        const updatedRow = await updateInfrastructureServerForUser(rec.id, userId, {
+          provider: rec.provider,
+          region: rec.region,
+          name: rec.name,
+          role: rec.role,
+          environment: rec.environment,
+          notes: rec.notes,
+          consoleUrl: rec.consoleUrl,
+          runbookUrl: rec.runbookUrl,
+          tags: rec.tags,
+          linkedDomainIds: rec.linkedDomainIds,
+          updatedAt: now,
+        });
+        if (!updatedRow) {
+          errors.push({ row: rowNum, message: "Update failed" });
+          continue;
+        }
+        updated += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        created += 1;
+        continue;
+      }
+
+      const now = new Date();
+      const insert: InfrastructureServerInsert = {
+        id: rec.id,
+        userId,
+        provider: rec.provider,
+        region: rec.region,
+        name: rec.name,
+        role: rec.role,
+        environment: rec.environment,
+        notes: rec.notes,
+        consoleUrl: rec.consoleUrl,
+        runbookUrl: rec.runbookUrl,
+        tags: rec.tags,
+        linkedDomainIds: rec.linkedDomainIds,
+        createdAt: rec.createdAt ? new Date(rec.createdAt) : now,
+        updatedAt: rec.updatedAt ? new Date(rec.updatedAt) : now,
+      };
+
+      const inserted = await insertInfrastructureServer(insert);
+      if (!inserted) {
+        errors.push({ row: rowNum, message: "Insert failed" });
+        continue;
+      }
+      created += 1;
+    }
+
+    return {
+      status: 200,
+      body: {
+        dryRun,
+        created,
+        updated,
+        skipped,
+        errors,
+      },
+    };
+  } catch (e) {
+    return dbFailureBody(e);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added portfolio export functionality for domains and servers in JSON and CSV formats.
  * Added portfolio import functionality for domains and servers from JSON and CSV files with validation.
  * Introduced dry-run mode for imports to preview changes before applying them.
  * Added configurable duplicate handling policies (skip, update, or error) for domains and servers.
  * Import results now display summary counts and detailed per-row error messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zhravan/proxydeck/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->